### PR TITLE
heap_help: fix a bug in realloc() tracking

### DIFF
--- a/utils/heap_help/heap_help.c
+++ b/utils/heap_help/heap_help.c
@@ -630,7 +630,7 @@ realloc(void *ptr, size_t size)
 		alloc_trace_new(res, size);
 	} else if (ptr != NULL && res == NULL) {
 		alloc_untrace(ptr);
-	} else if (ptr != NULL && res != ptr) {
+	} else {
 		alloc_untrace(ptr);
 		alloc_trace_new(res, size);
 	}


### PR DESCRIPTION
Need to update the tracked allocation's size when it gets changed. Otherwise the HHCONTENT=t might trash valid data.